### PR TITLE
_perform_request should attempt to parse the body for valid XML if the HTTP status code is not 200 OK

### DIFF
--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -652,7 +652,6 @@ class OpenADRClient:
                 if req.status != HTTPStatus.OK:
                     logger.warning(f"Non-OK status when performing a request to {url} with data "
                                    f"{message}: {req.status} {content.decode('utf-8')}")
-                    return None, {}
                 logger.debug(content.decode('utf-8'))
         except aiohttp.client_exceptions.ClientConnectorError as err:
             # Could not connect to server


### PR DESCRIPTION
If the HTTP status code from the VTN is not 200, don't immediate return None. The VTN may return a valid OpenADR payload with a 4xx HTTP status code, and this payload should be parsed and the response_description returned later