### PR TITLE
Add Developing with Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,16 @@ To run the test suite, you can use the following command:
 ./python_env/bin/python3 -m pytest -v test/
 ```
 
+## Developing with Docker
+
+It can also use following command to download Docker image to complete the development setup for working with OpenLEADR:
+
+```bash
+docker pull peter279k/openleadr-python:latest
+```
+
+Running Docker image as the container on the background:
+
+```bash
+docker run --name=openleadr-python -it -d peter279k/openleadr-python:latest
+```


### PR DESCRIPTION
Signed-off-by: peter279k <peter279k@gmail.com>

# Changed log

- Adding the `Developing with Docker section` for Docker lovers :).
- The Docker image project is available on [GitHub repository](https://github.com/peter279k/openleadr-python-docker).
   - The Docker image provides the Python `3.7`, `3.8` and `3.9` versions.
   - Using the official Python Docker image to build three different development openleadr-python with different Python versions.
- The Docker image is available on [Docker hub](https://hub.docker.com/r/peter279k/openleadr-python).