### PR TITLE
Add option to disable signing messages; update docs, README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .pytest_cache/
 .ipynb_checkpoints/
 static/
+.idea/

--- a/README.md
+++ b/README.md
@@ -78,3 +78,24 @@ To run the test suite, you can use the following command:
 ./python_env/bin/python3 -m pytest -v test/
 ```
 
+## Contributing Documentation
+
+### Building the documentation
+
+Static documentation can be found in the docs directory. Edit or create new .rst files to add new content using 
+the [Restructured Text](http://docutils.sourceforge.net/docs/user/rst/quickref.html) format. To see the results of your changes,
+the documentation can be built locally through the command line using the following instructions:
+
+```bash
+# Ensure that you follow the development setup in the Developing section above before running the following commands
+# After running this these commands, you should see a new directory `docs/_build`, which contains the HTML documentation. 
+# For more details, see https://www.sphinx-doc.org/en/master/tutorial/first-steps.html  
+cd docs
+make html
+```
+
+Then, open your browser to the created local files:
+
+```
+file:///home/<USER>/openleadr-python/docs/_build/html/index.html
+```

--- a/docs/api/openleadr.rst
+++ b/docs/api/openleadr.rst
@@ -36,6 +36,14 @@ openleadr.fingerprint module
    :undoc-members:
    :show-inheritance:
 
+openleadr.hooks module
+----------------------
+
+.. automodule:: openleadr.hooks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 openleadr.messaging module
 --------------------------
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -146,7 +146,7 @@ Signing outgoing messages
 
 You can sign your outgoing messages using a public-private key pair in PEM format. This allows the receiving party to verify that the messages are actually coming from you.
 
-If you want you client to automatically sign your outgoing messages, use the following configuration:
+If you want your client to automatically sign your outgoing messages, use the following configuration:
 
 .. code-block:: python3
 
@@ -156,6 +156,22 @@ If you want you client to automatically sign your outgoing messages, use the fol
                                cert='/path/to/cert.pem',
                                key='/path/to/key.pem',
                                passphrase='my-key-password')
+        ...
+
+
+In some odd cases in which the VTN that you are connecting to does not support signatures
+(e.g. legacy VTN's that have not been updated to the latest OpenADR protocol),
+you can disable the automatic signing of outgoing message with the following configuration:
+
+.. code-block:: python3
+
+    async def main():
+        client = OpenADRClient(ven_name='MyVEN',
+                               vtn_url='https://localhost:8080/',
+                               cert='/path/to/cert.pem',
+                               key='/path/to/key.pem',
+                               passphrase='my-key-password',
+                               disable_signature=True)
         ...
 
 .. _client_validating_messages:

--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -32,6 +32,7 @@ from openleadr.messaging import create_message, parse_message, \
 from openleadr import utils
 
 logger = logging.getLogger('openleadr')
+logger.setLevel(logging.INFO)
 
 
 class OpenADRClient:
@@ -782,7 +783,7 @@ class OpenADRClient:
                 if asyncio.iscoroutine(result):
                     result = await result
                 results.append(result)
-                if event_status in (enums.EVENT_STATUS.COMPLETED, enums.EVENT_STATUS.CANCELLED):
+                if event_status in (enums.EVENT_STATUS.COMPLETED, enums.EVENT_STATUS.CANCELLED) and event_id in self.responded_events:
                     self.responded_events.pop(event_id)
                 else:
                     self.responded_events[event_id] = result
@@ -807,6 +808,7 @@ class OpenADRClient:
                            and not utils.determine_event_status(event['active_period']) == 'completed']
 
         if len(event_responses) > 0:
+            logger.info(f"Total event_responses: {len(event_responses)}")
             response = {'response_code': 200,
                         'response_description': 'OK',
                         'request_id': message['request_id']}
@@ -849,6 +851,7 @@ class OpenADRClient:
 
         elif response_type == 'oadrDistributeEvent':
             if 'events' in response_payload and len(response_payload['events']) > 0:
+                logger.info(f"The payload tyupe {type(response_payload)}")
                 await self._on_event(response_payload)
 
         elif response_type == 'oadrUpdateReport':

--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -41,7 +41,7 @@ class OpenADRClient:
     """
     def __init__(self, ven_name, vtn_url, debug=False, cert=None, key=None,
                  passphrase=None, vtn_fingerprint=None, show_fingerprint=True, ca_file=None,
-                 allow_jitter=True, ven_id=None):
+                 allow_jitter=True, ven_id=None, disable_signature=False):
         """
         Initializes a new OpenADR Client (Virtual End Node)
 
@@ -61,6 +61,7 @@ class OpenADRClient:
                             certificate.
         :param str ven_id: The ID for this VEN. If you leave this blank,
                            a VEN_ID will be assigned by the VTN.
+        :param bool disable_signature: Whether or not to sign outgoing messages using a public-private key pair in PEM format.
         """
 
         self.ven_name = ven_name
@@ -109,7 +110,8 @@ class OpenADRClient:
         self._create_message = partial(create_message,
                                        cert=cert,
                                        key=key,
-                                       passphrase=passphrase)
+                                       passphrase=passphrase,
+                                       disable_signature=disable_signature)
 
     async def run(self):
         """

--- a/test/integration_tests/test_client_registration.py
+++ b/test/integration_tests/test_client_registration.py
@@ -82,16 +82,16 @@ def fingerprint_lookup(ven_id):
     return certificate_fingerprint(cert)
 
 @pytest.mark.asyncio
-async def test_create_party_registration_with_signatures(start_server_with_signatures):
+@pytest.mark.parametrize("disable_signature", [False, True])
+async def test_create_party_registration_with_signatures(start_server_with_signatures, disable_signature):
     with open(CERTFILE) as file:
         cert = file.read()
     client = OpenADRClient(ven_name=VEN_NAME,
                            vtn_url=f"http://localhost:{SERVER_PORT}/OpenADR2/Simple/2.0b",
-                           cert=CERTFILE, key=KEYFILE, vtn_fingerprint=certificate_fingerprint(cert))
+                           cert=CERTFILE, key=KEYFILE, vtn_fingerprint=certificate_fingerprint(cert),
+                           disable_signature=disable_signature)
 
     response_type, response_payload = await client.create_party_registration()
     assert response_type == 'oadrCreatedPartyRegistration'
     assert response_payload['ven_id'] == VEN_ID
     await client.stop()
-
-

--- a/test/test_certificates.py
+++ b/test/test_certificates.py
@@ -33,7 +33,8 @@ async def on_create_party_registration(payload, future):
         return 'ven1234', 'reg5678'
 
 @pytest.mark.asyncio
-async def test_ssl_certificates():
+@pytest.mark.parametrize("disable_signature", [False, True])
+async def test_ssl_certificates(disable_signature):
     loop = asyncio.get_event_loop()
     registration_future = loop.create_future()
     server = OpenADRServer(vtn_id='myvtn',
@@ -53,7 +54,7 @@ async def test_ssl_certificates():
                            cert=VEN_CERT,
                            key=VEN_KEY,
                            ca_file=CA_CERT,
-                           vtn_fingerprint=vtn_fingerprint)
+                           vtn_fingerprint=vtn_fingerprint, disable_signature=disable_signature)
     await client.run()
 
     # Wait for the registration to be triggered

--- a/test/test_signatures.py
+++ b/test/test_signatures.py
@@ -16,7 +16,7 @@
 
 
 from openleadr.utils import generate_id, certificate_fingerprint, ensure_bytes
-from openleadr.messaging import create_message, parse_message, validate_xml_signature, validate_xml_schema
+from openleadr.messaging import create_message, parse_message, validate_xml_signature, validate_xml_schema, validate_xml_signature_none
 from hashlib import sha256
 from base64 import b64encode
 from datetime import datetime, timedelta, timezone
@@ -35,6 +35,14 @@ def test_message_validation():
     validate_xml_signature(tree)
     parsed_type, parsed_message = parse_message(msg)
     assert parsed_type == 'oadrPoll'
+
+def test_message_validation_disable_signature():
+    msg = create_message('oadrPoll', ven_id='123', cert=TEST_CERT, key=TEST_KEY, disable_signature=True)
+    tree = etree.fromstring(msg.encode('utf-8'))
+    validate_xml_signature_none(tree)
+    parsed_type, parsed_message = parse_message(msg)
+    assert parsed_type == 'oadrPoll'
+
 
 def test_message_validation_complex():
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
### What are the changes?
* Added optional configuration, disable_signature, to OpenADRClient
* Added optional parameter, disable_signature (default set to False), to ```create_message``` in messaging.py
* Added tests in test_signatures.py, integration_tests/test_client_registration.py, and test_certificates.py
* Updated documentation to highlight the use of the disable_signature configuration
* Updated README to include instructions on generating documentation locally

### Why is it needed?
* To address edge cases in which VEN clients connect to legacy VTN's that don't support signatures as highlighted in #69 


### Testing
Ran full suite of tests. All tests passed. Results pasted below for reference.

```shell
./python_env/bin/python3 -m pytest -v test/
```

<details> <summary>CLICK TO EXPAND FULL TEST RESULTS</summary> 
============================= test session starts ==============================
platform darwin -- Python 3.8.2, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /Users/boni407/Workplace/volttron-project/openleadr-python/python_env/bin/python3
cachedir: .pytest_cache
rootdir: /Users/boni407/Workplace/volttron-project/openleadr-python
plugins: asyncio-0.15.1
collecting ... collected 185 items

test/test_certificates.py::test_ssl_certificates[False] PASSED           [  0%]
test/test_certificates.py::test_ssl_certificates[True] PASSED            [  1%]
test/test_certificates.py::test_ssl_certificates_wrong_cert PASSED       [  1%]
test/test_certificates.py::test_ssl_certificates_wrong_fingerprint PASSED [  2%]
test/test_client_misc.py::test_trailing_slash_on_vtn_url PASSED          [  2%]
test/test_client_misc.py::test_wrong_handler_supplied PASSED             [  3%]
test/test_client_misc.py::test_invalid_report_name PASSED                [  3%]
test/test_client_misc.py::test_invalid_reading_type PASSED               [  4%]
test/test_client_misc.py::test_invalid_report_type PASSED                [  4%]
test/test_client_misc.py::test_invalid_data_collection_mode PASSED       [  5%]
test/test_client_misc.py::test_invalid_scale PASSED                      [  5%]
test/test_client_misc.py::test_add_report_without_specifier_id PASSED    [  6%]
test/test_client_misc.py::test_add_report_with_invalid_callback_signature PASSED [  7%]
test/test_errors.py::test_protocol_errors PASSED                         [  7%]
test/test_event_distribution.py::test_internal_message_queue PASSED      [  8%]
test/test_event_distribution.py::test_request_event PASSED               [  8%]
test/test_event_distribution.py::test_raw_event PASSED                   [  9%]
test/test_event_distribution.py::test_create_event_with_future_as_callback PASSED [  9%]
test/test_event_distribution.py::test_multiple_events_in_queue PASSED    [ 10%]
test/test_event_distribution.py::test_client_event_cleanup PASSED        [ 10%]
test/test_event_distribution.py::test_cancel_event PASSED                [ 11%]
test/test_event_distribution.py::test_event_external_polling_function PASSED [ 11%]
test/test_failures.py::test_http_level_error PASSED                      [ 12%]
test/test_failures.py::test_xml_schema_error PASSED                      [ 12%]
test/test_failures.py::test_wrong_endpoint PASSED                        [ 13%]
test/test_failures.py::test_vtn_no_create_party_registration_handler PASSED [ 14%]
test/test_failures.py::test_server_handler_exception PASSED              [ 14%]
test/test_failures.py::test_throw_protocol_error PASSED                  [ 15%]
test/test_failures.py::test_invalid_signature_error PASSED               [ 15%]
test/test_failures.py::test_replay_protect_message_too_old PASSED        [ 16%]
test/test_failures.py::test_replay_protect_repeated_message PASSED       [ 16%]
test/test_failures.py::test_replay_protect_missing_nonce PASSED          [ 17%]
test/test_failures.py::test_replay_protect_malformed_nonce PASSED        [ 17%]
test/test_failures.py::test_server_add_unknown_handler PASSED            [ 18%]
test/test_failures.py::test_server_add_event_with_invalid_signal_type PASSED [ 18%]
test/test_failures.py::test_server_add_event_with_invalid_signal_name PASSED [ 19%]
test/test_failures.py::test_server_add_event_with_custom_signal_name PASSED [ 20%]
test/test_failures.py::test_server_add_event_with_no_intervals PASSED    [ 20%]
test/test_fingerprint_cmdline.py::test_fingerprint_cmdline PASSED        [ 21%]
test/test_message_conversion.py::test_message[oadrCanceledOpt-data0] PASSED [ 21%]
test/test_message_conversion.py::test_message[oadrCanceledPartyRegistration-data1] PASSED [ 22%]
test/test_message_conversion.py::test_message[oadrCanceledReport-data2] PASSED [ 22%]
test/test_message_conversion.py::test_message[oadrCancelOpt-data3] PASSED [ 23%]
test/test_message_conversion.py::test_message[oadrCancelPartyRegistration-data4] PASSED [ 23%]
test/test_message_conversion.py::test_message[oadrCancelReport-data5] PASSED [ 24%]
test/test_message_conversion.py::test_message[oadrCreatedEvent-data6] PASSED [ 24%]
test/test_message_conversion.py::test_message[oadrCreatedReport-data7] PASSED [ 25%]
test/test_message_conversion.py::test_message[oadrCreatedEvent-data8] PASSED [ 25%]
test/test_message_conversion.py::test_message[oadrCreatedPartyRegistration-data9] PASSED [ 26%]
test/test_message_conversion.py::test_message[oadrCreatedReport-data10] PASSED [ 27%]
test/test_message_conversion.py::test_message[oadrCreateOpt-data11] PASSED [ 27%]
test/test_message_conversion.py::test_message[oadrCreatePartyRegistration-data12] PASSED [ 28%]
test/test_message_conversion.py::test_message[oadrCreateReport-data13] PASSED [ 28%]
test/test_message_conversion.py::test_message[oadrDistributeEvent-data14] PASSED [ 29%]
test/test_message_conversion.py::test_message[oadrDistributeEvent-data15] PASSED [ 29%]
test/test_message_conversion.py::test_message[oadrPoll-data16] PASSED    [ 30%]
test/test_message_conversion.py::test_message[oadrQueryRegistration-data17] PASSED [ 30%]
test/test_message_conversion.py::test_message[oadrRegisteredReport-data18] PASSED [ 31%]
test/test_message_conversion.py::test_message[oadrRequestEvent-data19] PASSED [ 31%]
test/test_message_conversion.py::test_message[oadrRequestReregistration-data20] PASSED [ 32%]
test/test_message_conversion.py::test_message[oadrRegisterReport-data21] PASSED [ 32%]
test/test_message_conversion.py::test_message[oadrRegisterReport-data22] PASSED [ 33%]
test/test_message_conversion.py::test_message[oadrRegisterReport-data23] PASSED [ 34%]
test/test_message_conversion.py::test_message[oadrResponse-data24] PASSED [ 34%]
test/test_message_conversion.py::test_message[oadrResponse-data25] PASSED [ 35%]
test/test_message_conversion.py::test_message[oadrUpdatedReport-data26] PASSED [ 35%]
test/test_message_conversion.py::test_message[oadrUpdateReport-data27] PASSED [ 36%]
test/test_objects.py::test_oadr_event PASSED                             [ 36%]
test/test_objects.py::test_oadr_event_targets_by_type PASSED             [ 37%]
test/test_objects.py::test_oadr_event_targets_and_targets_by_type PASSED [ 37%]
test/test_objects.py::test_oadr_event_targets_and_targets_by_type_invalid PASSED [ 38%]
test/test_objects.py::test_oadr_event_no_targets PASSED                  [ 38%]
test/test_objects.py::test_event_signal_with_grouped_targets PASSED      [ 39%]
test/test_objects.py::test_event_signal_with_incongruent_targets PASSED  [ 40%]
test/test_objects.py::test_event_descriptor_modification_number PASSED   [ 40%]
test/test_poll_responses.py::test_message[oadrResponse-message_payload0] PASSED [ 41%]
test/test_poll_responses.py::test_message[oadrDistributeEvent-message_payload1] PASSED [ 41%]
test/test_poll_responses.py::test_message[oadrCreateReport-message_payload2] PASSED [ 42%]
test/test_poll_responses.py::test_message[oadrCancelReport-message_payload3] PASSED [ 42%]
test/test_poll_responses.py::test_message[oadrRegisterReport-message_payload4] PASSED [ 43%]
test/test_poll_responses.py::test_message[oadrUpdateReport-message_payload5] PASSED [ 43%]
test/test_poll_responses.py::test_message[oadrCancelPartyRegistration-message_payload6] PASSED [ 44%]
test/test_poll_responses.py::test_message[oadrRequestReregistration-message_payload7] PASSED [ 44%]
test/test_reports.py::test_report_registration PASSED                    [ 45%]
test/test_reports.py::test_report_registration_with_status_report PASSED [ 45%]
test/test_reports.py::test_report_registration_full PASSED               [ 46%]
test/test_reports.py::test_update_reports PASSED                         [ 47%]
test/test_reports.py::test_incremental_reports PASSED                    [ 47%]
test/test_reports.py::test_update_report_data_collection_mode_full PASSED [ 48%]
test/test_reports.py::test_add_report_invalid_unit PASSED                [ 48%]
test/test_reports.py::test_add_report_invalid_scale PASSED               [ 49%]
test/test_reports.py::test_add_report_invalid_description PASSED         [ 49%]
test/test_reports.py::test_add_report_non_standard_measurement PASSED    [ 50%]
test/test_reports.py::test_different_on_register_report_handlers PASSED  [ 50%]
test/test_reports.py::test_report_registration_broken_handlers_raw_message PASSED [ 51%]
test/test_reports.py::test_register_historic_report PASSED               [ 51%]
test/test_schema.py::test_message[oadrCanceledOpt-payload0] PASSED       [ 52%]
test/test_schema.py::test_message[oadrCanceledPartyRegistration-payload1] PASSED [ 52%]
test/test_schema.py::test_message[oadrCanceledReport-payload2] PASSED    [ 53%]
test/test_schema.py::test_message[oadrCanceledReport-payload3] PASSED    [ 54%]
test/test_schema.py::test_message[oadrCancelOpt-payload4] PASSED         [ 54%]
test/test_schema.py::test_message[oadrCancelPartyRegistration-payload5] PASSED [ 55%]
test/test_schema.py::test_message[oadrCancelReport-payload6] PASSED      [ 55%]
test/test_schema.py::test_message[oadrCreatedEvent-payload7] PASSED      [ 56%]
test/test_schema.py::test_message[oadrCreatedReport-payload8] PASSED     [ 56%]
test/test_schema.py::test_message[oadrCreatedEvent-payload9] PASSED      [ 57%]
test/test_schema.py::test_message[oadrCreatedPartyRegistration-payload10] PASSED [ 57%]
test/test_schema.py::test_message[oadrCreatedReport-payload11] PASSED    [ 58%]
test/test_schema.py::test_message[oadrCreateOpt-payload12] PASSED        [ 58%]
test/test_schema.py::test_message[oadrCreatePartyRegistration-payload13] PASSED [ 59%]
test/test_schema.py::test_message[oadrCreateReport-payload14] PASSED     [ 60%]
test/test_schema.py::test_message[oadrDistributeEvent-payload15] PASSED  [ 60%]
test/test_schema.py::test_message[oadrPoll-payload16] PASSED             [ 61%]
test/test_schema.py::test_message[oadrQueryRegistration-payload17] PASSED [ 61%]
test/test_schema.py::test_message[oadrRegisteredReport-payload18] PASSED [ 62%]
test/test_schema.py::test_message[oadrRequestEvent-payload19] PASSED     [ 62%]
test/test_schema.py::test_message[oadrRequestReregistration-payload20] PASSED [ 63%]
test/test_schema.py::test_message[oadrRegisterReport-payload21] PASSED   [ 63%]
test/test_schema.py::test_message[oadrRegisterReport-payload22] PASSED   [ 64%]
test/test_schema.py::test_message[oadrResponse-payload23] PASSED         [ 64%]
test/test_schema.py::test_message[oadrResponse-payload24] PASSED         [ 65%]
test/test_schema.py::test_message[oadrUpdatedReport-payload25] PASSED    [ 65%]
test/test_schema.py::test_message[oadrUpdateReport-payload26] PASSED     [ 66%]
test/test_signatures.py::test_message_validation PASSED                  [ 67%]
test/test_signatures.py::test_message_validation_disable_signature PASSED [ 67%]
test/test_signatures.py::test_message_validation_complex PASSED          [ 68%]
test/test_utils.py::test_hasmember PASSED                                [ 68%]
test/test_utils.py::test_getmember PASSED                                [ 69%]
test/test_utils.py::test_setmember PASSED                                [ 69%]
test/test_utils.py::test_setmember_nested PASSED                         [ 70%]
test/test_utils.py::test_determine_event_status_completed PASSED         [ 70%]
test/test_utils.py::test_determine_event_status_active PASSED            [ 71%]
test/test_utils.py::test_determine_event_status_near PASSED              [ 71%]
test/test_utils.py::test_determine_event_status_far PASSED               [ 72%]
test/test_utils.py::test_determine_event_status_far_with_ramp_up PASSED  [ 72%]
test/test_utils.py::test_get_active_period_from_intervals PASSED         [ 73%]
test/test_utils.py::test_cron_config PASSED                              [ 74%]
test/test_utils.py::test_validate_report_measurement_dict_missing_items PASSED [ 74%]
test/test_utils.py::test_validate_report_measurement_dict_invalid_name PASSED [ 75%]
test/test_utils.py::test_validate_report_measurement_dict_invalid_unit PASSED [ 75%]
test/test_utils.py::test_validate_report_measurement_dict_invalid_description PASSED [ 76%]
test/test_utils.py::test_validate_report_measurement_dict_invalid_description_case PASSED [ 76%]
test/test_utils.py::test_validate_report_measurement_dict_missing_power_attributes PASSED [ 77%]
test/test_utils.py::test_validate_report_measurement_dict_invalid_power_attributes PASSED [ 77%]
test/test_utils.py::test_ungroup_target_by_type_with_single_str PASSED   [ 78%]
test/test_utils.py::test_find_by_with_dict PASSED                        [ 78%]
test/test_utils.py::test_find_by_with_missing_member PASSED              [ 79%]
test/test_utils.py::test_find_by_nested_dict PASSED                      [ 80%]
test/test_utils.py::test_pop_by PASSED                                   [ 80%]
test/test_utils.py::test_ensure_str PASSED                               [ 81%]
test/test_utils.py::test_ensure_bytes PASSED                             [ 81%]
test/test_utils.py::test_booleanformat PASSED                            [ 82%]
test/test_utils.py::test_parse_duration PASSED                           [ 82%]
test/test_utils.py::test_parse_datetime PASSED                           [ 83%]
test/test_utils.py::test_await_if_required PASSED                        [ 83%]
test/test_utils.py::test_gather_if_required PASSED                       [ 84%]
test/test_utils.py::test_order_events PASSED                             [ 84%]
test/test_utils.py::test_increment_modification_number PASSED            [ 85%]
test/conformance/test_conformance_001.py::test_conformance_001 PASSED    [ 85%]
test/conformance/test_conformance_002.py::test_conformance_002 PASSED    [ 86%]
test/conformance/test_conformance_006.py::test_conformance_006 PASSED    [ 87%]
test/conformance/test_conformance_008.py::test_conformance_008_autocorrect PASSED [ 87%]
test/conformance/test_conformance_008.py::test_conformance_008_raise PASSED [ 88%]
test/conformance/test_conformance_009.py::test_conformance_009_pass PASSED [ 88%]
test/conformance/test_conformance_009.py::test_conformance_009_raise PASSED [ 89%]
test/conformance/test_conformance_014.py::test_conformance_014_warn PASSED [ 89%]
test/conformance/test_conformance_021.py::test_conformance_021 PASSED    [ 90%]
test/integration_tests/test_client_registration.py::test_query_party_registration PASSED [ 90%]
test/integration_tests/test_client_registration.py::test_create_party_registration PASSED [ 91%]
test/integration_tests/test_client_registration.py::test_create_party_registration_with_signatures[False] PASSED [ 91%]
test/integration_tests/test_client_registration.py::test_create_party_registration_with_signatures[True] PASSED [ 92%]
test/integration_tests/test_event_warnings_errors.py::test_client_no_event_handler PASSED [ 92%]
test/integration_tests/test_event_warnings_errors.py::test_client_faulty_event_handler PASSED [ 93%]
test/integration_tests/test_event_warnings_errors.py::test_client_exception_event_handler PASSED [ 94%]
test/integration_tests/test_event_warnings_errors.py::test_client_good_event_handler PASSED [ 94%]
test/integration_tests/test_event_warnings_errors.py::test_server_warning_conflicting_poll_methods PASSED [ 95%]
test/integration_tests/test_event_warnings_errors.py::test_server_warning_naive_datetimes_in_event PASSED [ 95%]
test/integration_tests/test_event_warnings_errors.py::test_event_with_wrong_response_required PASSED [ 96%]
test/integration_tests/test_event_warnings_errors.py::test_event_missing_created_date_time PASSED [ 96%]
test/integration_tests/test_event_warnings_errors.py::test_event_incongruent_targets PASSED [ 97%]
test/integration_tests/test_event_warnings_errors.py::test_event_only_targets_by_type PASSED [ 97%]
test/integration_tests/test_event_warnings_errors.py::test_client_warning_no_update_event_handler PASSED [ 98%]
test/integration_tests/test_event_warnings_errors.py::test_server_add_event_with_wrong_callback_signature PASSED [ 98%]
test/integration_tests/test_event_warnings_errors.py::test_server_add_event_with_no_callback PASSED [ 99%]
test/integration_tests/test_event_warnings_errors.py::test_server_add_event_with_no_callback_response_never_required PASSED [100%]

============================= 185 passed in 22.80s =============================

</details>

### Screenshots of updated documentation:

![Screen Shot 2021-10-01 at 3 03 17 PM](https://user-images.githubusercontent.com/6901848/135690950-d0bd2412-6ae7-4736-86d0-016c852c4cca.png)

![Screen Shot 2021-10-01 at 2 24 09 PM](https://user-images.githubusercontent.com/6901848/135690825-9f207e36-c7ea-4dd5-a7f2-0231b1d8cd14.png)


