### PR TITLE
Expat changes causing issues

### DIFF
--- a/openleadr/messaging.py
+++ b/openleadr/messaging.py
@@ -49,7 +49,7 @@ def parse_message(data):
 
     Returns a message type (str) and a message payload (dict)
     """
-    message_dict = xmltodict.parse(data, process_namespaces=True, namespaces=NAMESPACES)
+    message_dict = xmltodict.parse(data, process_namespaces=True, namespaces=NAMESPACES, namespace_separator=' ')
     message_type, message_payload = message_dict['oadrPayload']['oadrSignedObject'].popitem()
     message_payload = utils.normalize_dict(message_payload)
     return message_type, message_payload


### PR DESCRIPTION
Recent changes in the `expat` library now cause OpenLEADR to fail using:
```
libexpat1:
  Installed: 2.2.9-1ubuntu0.2
  Candidate: 2.2.9-1ubuntu0.2
  Version table:
 *** 2.2.9-1ubuntu0.2 500
        500 http://gb.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages
        100 /var/lib/dpkg/status
     2.2.9-1build1 500
        500 http://gb.archive.ubuntu.com/ubuntu focal/main amd64 Packages
```
This is due to using `xmltodict` with its default namespace separator ':', which is problematic for the new `expat` library. https://github.com/libexpat/libexpat/issues/572 has more details and more importantly, seems to be recommending that `xmltodict` itself should change or the applications using `xmltodict` (like OpenLEADR).

This PR is to specify a different namespace separator for `xmltodict` (' '). This seems to fix the problem but I have not tested thoroughly.