### PR TITLE
Cleaned up the logging of XML messages

### DIFF
--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -750,7 +750,6 @@ class OpenADRClient:
 
     async def _perform_request(self, service, message):
         await self._ensure_client_session()
-        logger.debug(f"Client is sending {message}")
         url = f"{self.vtn_url}/{service}"
         try:
             async with self.client_session.post(url, data=message) as req:
@@ -759,7 +758,6 @@ class OpenADRClient:
                     logger.warning(f"Non-OK status {req.status} when performing a request to {url} "
                                    f"with data {message}: {req.status} {content.decode('utf-8')}")
                     return None, {}
-                logger.debug(content.decode('utf-8'))
         except aiohttp.client_exceptions.ClientConnectorError as err:
             # Could not connect to server
             logger.error(f"Could not connect to server with URL {self.vtn_url}:")

--- a/openleadr/messaging.py
+++ b/openleadr/messaging.py
@@ -49,6 +49,13 @@ def parse_message(data):
 
     Returns a message type (str) and a message payload (dict)
     """
+    try:
+        if isinstance(data, bytes):
+            logger.debug(f"Parsing message: {data.decode('utf-8')}")
+        else:
+            logger.debug(f"Parsing message: {data}")
+    except UnicodeDecodeError:
+        logger.warning(f"Could not decode incoming message as UTF-8: {str(data)}")
     message_dict = xmltodict.parse(data, process_namespaces=True, namespaces=NAMESPACES)
     message_type, message_payload = message_dict['oadrPayload']['oadrSignedObject'].popitem()
     message_payload = utils.normalize_dict(message_payload)
@@ -77,6 +84,7 @@ def create_message(message_type, cert=None, key=None, passphrase=None, disable_s
     msg = envelope.render(template=f'{message_type}',
                           signature=signature,
                           signed_object=signed_object)
+    logger.debug(f"Created message: {msg}")
     return msg
 
 

--- a/test/conformance/test_conformance_008.py
+++ b/test/conformance/test_conformance_008.py
@@ -68,7 +68,7 @@ async def test_conformance_008_autocorrect(caplog):
                          vtn_id=generate_id(),
                          events=[event])
 
-    assert caplog.record_tuples == [("openleadr", logging.WARNING, f"The active_period duration for event {event_id} (0:05:00) differs from the sum of the interval's durations (0:30:00). The active_period duration has been adjusted to (0:30:00).")]
+    assert ("openleadr", logging.WARNING, f"The active_period duration for event {event_id} (0:05:00) differs from the sum of the interval's durations (0:30:00). The active_period duration has been adjusted to (0:30:00).") in caplog.record_tuples
 
     parsed_type, parsed_msg = parse_message(msg)
     assert parsed_type == 'oadrDistributeEvent'

--- a/test/conformance/test_conformance_014.py
+++ b/test/conformance/test_conformance_014.py
@@ -67,5 +67,5 @@ async def test_conformance_014_warn(caplog):
                          vtn_id=generate_id(),
                          events=[event])
 
-    assert caplog.record_tuples == [("openleadr", logging.WARNING, "The current_value for a SIMPLE event that is not yet active must be 0. This will be corrected.")]
+    assert ("openleadr", logging.WARNING, "The current_value for a SIMPLE event that is not yet active must be 0. This will be corrected.") in caplog.record_tuples
 


### PR DESCRIPTION
The logging of XML messages is now done within the parse_message and
create_message functions. This makes it easier and more consistent.

In the future, we should probably add relevant hook points here so that
these things can be logged to a database or other system.

Reported in #110 