### PR TITLE
WIP: 500 error in VTN when VEN creates a single report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(name='openleadr',
       packages=['openleadr', 'openleadr.service'],
       python_requires='>=3.7.0',
       include_package_data=True,
-      install_requires=['xmltodict', 'aiohttp', 'apscheduler', 'jinja2', 'signxml-openadr==2.9.1'],
+      install_requires=['xmltodict', 'aiohttp', 'apscheduler', 'glom', 'jinja2', 'signxml-openadr==2.9.1'],
       entry_points={'console_scripts': ['fingerprint = openleadr.fingerprint:show_fingerprint']})

--- a/test/test_message_conversion.py
+++ b/test/test_message_conversion.py
@@ -110,6 +110,7 @@ testcases = [
                                                   {'response_code': 200, 'response_description': 'OK', 'request_id': generate_id(), 'event_id': generate_id(), 'modification_number': 1, 'opt_type': 'optIn'},
                                                   {'response_code': 200, 'response_description': 'OK', 'request_id': generate_id(), 'event_id': generate_id(), 'modification_number': 1, 'opt_type': 'optIn'}],
                                  ven_id='123ABC')),
+('oadrCreatedReport', dict(response={'response_code': 200, 'response_description': 'OK', 'request_id': generate_id()}, pending_reports=[{'report_request_id': generate_id()}], ven_id='123ABC')),
 ('oadrCreatedReport', dict(response={'response_code': 200, 'response_description': 'OK', 'request_id': generate_id()}, pending_reports=[{'report_request_id': generate_id()}, {'report_request_id': generate_id()}], ven_id='123ABC')),
 ('oadrCreatedEvent', dict(response={'response_code': 200, 'response_description': 'OK', 'request_id': None},
                                  event_responses=[{'response_code': 200, 'response_description': 'OK', 'request_id': generate_id(),
@@ -271,8 +272,7 @@ testcases = [
                                                                                        'sampling_rate': {'min_period': timedelta(minutes=1),
                                                                                                          'max_period': timedelta(minutes=2),
                                                                                                          'on_change': False}}
-                                                                                        ]}], ven_id='123ABC'))
-
+                                                                                        ]}], ven_id='123ABC')),
 ]
 
 @pytest.mark.parametrize('message_type,data', testcases)


### PR DESCRIPTION
Hi Stan,

I discovered a bug in Openleadr's XML-to-object behaviour. The error path is approximately this:
- My VEN client had only a single report (created with `my_OpenADRClient.register_reports(report=[...])`)
- This gets correctly turned into XML and sent to the VTN.
- On the VTN, `xmltodict.parse` turns that single report entry (in the `<oadr:oadrPendingReports>` tag) into a dict with a bare string in it -- if there were more entries, it would produce a dist with a _list_ of strings. (Arguably, this is the source of the error ...)
- `openleadr.util.normalize_dict` fails to normalize that structure, because it only expects a dict with a list of strings. (... but this is the easiest place to fix it.)
- Further down the line, the VTN's `openleadr.service.report_service.ReportService.on_created_report` blows up and we get a 500 error.

For now, our workaround is to register a second, dummy, report on our VEN.

About this PR:
- First commit in this PR adds the failing test.
- Second commit in this PR contains one possible fix -- using [`glom`](https://glom.readthedocs.io/en/latest/matching.html), a library that specializes in extracting data from nested data structures. 

Motivation:
- The error is essentially a schema error: `xml2dict.parse`'s result has a different schema depending on if there are 0, 1, or more pending reports, and then `openleadr.util.normalize_dict` only handles one of those schemas.
- Python is really bad at checking a nested data structures: it forces you to write error-prone code like `if isinstance(d[key], dict) and 'report_request_id' in d[key] and isinstance(d[key]['report_request_id'], list)`.  _(Footnote: Python 3.10's [structural pattern matching](https://peps.python.org/pep-0636/) is perfect for extracting data from nested structures, and handling multiple cases. But I figure you want to keep supporting Python<=3.9 for a while longer.)_
- So a library that makes it easy to check and use schemas will make `openleadr.util.normalize_dict` easier to maintain. For this WIP proposal, I chose `glom`. (Another option might be [`schema`](https://github.com/keleshev/schema) might also be an option?)

Choices from here, depending on how you feel about Glom:
1. "Not feeling it": Rewrite the pending_reports schema checks using plain python `x in y and isinstance(y[x], mytype) and ...`
2. "Looks nice enough": Accept this PR, including Glom, as is; leave the rest of normalize_dict, we can use glom if more bugs crop up
3. "Let's try a few more cases": First (someone, probably me) rewrites the other ~16 transformations in `normalize_dict` to also use Glom where it makes sense. That's not much work.
- "Let's get radical": Fix this by solving #17 .

Any thoughts?

Cheers,
Sietse