### PR TITLE
Various fixes in VEN registration

### DIFF
--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -127,7 +127,16 @@ class OpenADRClient:
         # if not hasattr(self, 'on_event'):
         #     raise NotImplementedError("You must implement on_event.")
         self.loop = asyncio.get_event_loop()
-        await self.create_party_registration(ven_id=self.ven_id)
+
+        request_id = None
+        response_type, response_payload = await self.query_registration()
+        if 'registration_id' in response_payload:
+            self.registration_id = response_payload['registration_id']
+        if response_payload and 'response' in response_payload  and 'request_id' in response_payload['response']:
+            request_id = response_payload['response']['request_id']
+
+        await self.create_party_registration(ven_id=self.ven_id, request_id=request_id)
+
 
         if not self.registration_id:
             logger.error("No RegistrationID received from the VTN, aborting.")
@@ -394,7 +403,7 @@ class OpenADRClient:
     async def create_party_registration(self, http_pull_model=True, xml_signature=False,
                                         report_only=False, profile_name='2.0b',
                                         transport_name='simpleHttp', transport_address=None,
-                                        ven_id=None):
+                                        ven_id=None, request_id=None, registration_id=None):
         """
         Take the neccessary steps to register this client with the server.
 
@@ -407,7 +416,8 @@ class OpenADRClient:
         :param str transport_address: Which public-facing address the server should use
                                       to communicate.
         """
-        request_id = utils.generate_id()
+        if request_id is None:
+            request_id = utils.generate_id()
         service = 'EiRegisterParty'
         payload = {'ven_name': self.ven_name,
                    'ven_id': self.ven_id,
@@ -416,7 +426,8 @@ class OpenADRClient:
                    'report_only': report_only,
                    'profile_name': profile_name,
                    'transport_name': transport_name,
-                   'transport_address': transport_address}
+                   'transport_address': transport_address,
+                   'registration_id': registration_id}
 
         message = self._create_message('oadrCreatePartyRegistration',
                                        request_id=request_id,
@@ -456,8 +467,53 @@ class OpenADRClient:
             logger.info(f"The polling frequency is {self.poll_frequency}")
         return response_type, response_payload
 
+    async def create_party_reregistration(self, registration_id=None):
+        """
+        Take the neccessary steps to re-register this client with the server.
+        """
+
+        await self.create_party_registration(ven_id=self.ven_id, registration_id=registration_id)
+
+        if not self.registration_id:
+            logger.error("No RegistrationID received from the VTN, aborting.")
+            await self.stop()
+            return
+
+        await self.register_reports(self.reports)
+        if self.reports:
+            self.report_queue_task = self.loop.create_task(self._report_queue_worker())
+
+        # Perform initial event sync
+        await self.sync_events()
+
     async def cancel_party_registration(self):
-        raise NotImplementedError("Cancel Registration is not yet implemented")
+        if self.registration_id is None:
+            logger.info("VEN is not registered")
+            return
+
+        logger.info(f"VEN is registered with registration ID {self.registration_id} and venID {self.ven_id}, trying to un-register")
+        request_id = utils.generate_id()
+        payload = {'request_id': request_id,
+                   'registration_id': self.registration_id,
+                   'ven_id': self.ven_id}
+
+        service = 'EiRegisterParty'
+        message = self._create_message('oadrCancelPartyRegistration', **payload)
+        response_type, response_payload = await self._perform_request(service, message)
+
+        if response_type == 'oadrCanceledPartyRegistration' and response_payload['response']['response_code'] == 200:
+            logger.info("VEN successfully un-registered")
+            # Update/Delete all the registration and reports information
+            self.registration_id = None
+            self.report_requests = None
+            self.reports = None
+            self.report_callbacks = None
+            self.report_requests = None
+            self.incomplete_reports = None
+            self.pending_reports = None
+            self.scheduler.remove_all_jobs()
+        else:
+            logger.warning("The VEN couldn't cancel the registration")
 
     ###########################################################################
     #                                                                         #
@@ -514,6 +570,11 @@ class OpenADRClient:
         Tell the VTN about our reports. The VTN miht respond with an
         oadrCreateReport message that tells us which reports are to be sent.
         """
+
+        # When registering reports, they need to have the current time as the creation time
+        for report in reports:
+            report.created_date_time = datetime.now()
+
         request_id = utils.generate_id()
         payload = {'request_id': request_id,
                    'ven_id': self.ven_id,
@@ -522,6 +583,7 @@ class OpenADRClient:
 
         for report in payload['reports']:
             utils.setmember(report, 'report_request_id', 0)
+
 
         service = 'EiReport'
         message = self._create_message('oadrRegisterReport', **payload)
@@ -756,8 +818,31 @@ class OpenADRClient:
             return self.responded_events['event_id']
 
     async def on_cancel_party_registration(self, message):
+        if self.registration_id is None:
+            logger.info('VEN is not registered, doing nothing')
+            return
+        if 'registration_id' in message:
+            if self.registration_id != message['registration_id']:
+                logger.info(
+                    f"Cancel request is not for us: VEN registrationID is {self.registration_id}, requested for {message['registration_id']}")
+                response = {'response_code': 452,
+                            'response_description': 'ERROR',
+                            'request_id': message['request_id']}
+
+                message = self._create_message('oadrCanceledPartyRegistration', response=response, ven_id=self.ven_id,
+                                               registration_id=self.registration_id)
+                service = 'EiRegisterParty'
+                response_type, response_payload = await self._perform_request(service, message)
+                logger.info(response_type, response_payload)
+
+                return
+            else:
+                response = {'response_code': 200,
+                            'response_description': 'OK',
+                            'request_id': message['request_id']}
+        else:
+            return
         # Update/Delete all the registration and reports information
-        self.registration_id = None
         self.report_requests = None
         self.reports = None
         self.report_callbacks = None
@@ -766,12 +851,10 @@ class OpenADRClient:
         self.pending_reports = None
         self.scheduler.remove_all_jobs()
 
-        response = {'response_code': 200,
-                    'response_description': 'OK',
-                    'request_id': message['request_id']}
-        message = self._create_message('oadrCanceledPartyRegistration', response=response)
+        message = self._create_message('oadrCanceledPartyRegistration', response=response, ven_id=self.ven_id, registration_id=self.registration_id)
         service = 'EiRegisterParty'
         response_type, response_payload = await self._perform_request(service, message)
+        self.registration_id = None
         logger.info(response_type, response_payload)
 
     ###########################################################################
@@ -785,6 +868,7 @@ class OpenADRClient:
         Send an empty oadrResponse, for instance after receiving oadrRequestReregistration.
         """
         msg = self._create_message('oadrResponse',
+                                   ven_id=self.ven_id,
                                    response={'response_code': response_code,
                                              'response_description': response_description,
                                              'request_id': request_id})
@@ -963,6 +1047,7 @@ class OpenADRClient:
                            "does not support reports in this direction.")
             message = self._create_message('oadrRegisteredReport',
                                            report_requests=[],
+                                           ven_id=self.ven_id,
                                            response={'response_code': 200,
                                                      'response_description': 'OK',
                                                      'request_id': response_payload['request_id']})

--- a/openleadr/templates/oadrCreatePartyRegistration.xml
+++ b/openleadr/templates/oadrCreatePartyRegistration.xml
@@ -1,6 +1,9 @@
 <oadr:oadrSignedObject xmlns:oadr="http://openadr.org/oadr-2.0b/2012/07" oadr:Id="oadrSignedObject">
   <oadr:oadrCreatePartyRegistration ei:schemaVersion="2.0b" xmlns:ei="http://docs.oasis-open.org/ns/energyinterop/201110">
     <requestID xmlns="http://docs.oasis-open.org/ns/energyinterop/201110/payloads">{{ request_id }}</requestID>
+    {% if registration_id is defined and registration_id is not none %}
+    <ei:registrationID>{{ registration_id }}</ei:registrationID>
+    {% endif %}
     {% if ven_id is defined and ven_id is not none %}
     <ei:venID>{{ ven_id }}</ei:venID>
     {% endif %}

--- a/openleadr/templates/oadrRegisterReport.xml
+++ b/openleadr/templates/oadrRegisterReport.xml
@@ -27,6 +27,5 @@
     {% if ven_id is defined and ven_id is not none %}
     <ei:venID>{{ ven_id }}</ei:venID>
     {% endif %}
-    <ei:reportRequestID></ei:reportRequestID>
   </oadr:oadrRegisterReport>
 </oadr:oadrSignedObject>


### PR DESCRIPTION
- Fix oadrRegisterReport -> it shouldn't have a reportRequestID
- The registration process has to start with a OadrQueryRegistration
- The response to the oadrRegisterReport has to include the venID (#135)
- Implement cancel_party_registration (code probably could be cleaned, it's shares a lot with on_cancel_party_registration)
- In general, oadrResponse needs the venID, e.g. for oadrRequestReregistration
- Expand logic of on_cancel_party_registration
- Implement reregistration. Maybe this is not needed, some tests require the VEN to initiate a re-registration sending the registrationId and venID, and without sending them. This is the best (and fastest) way I could come up with a solution for this. In can certainly be better done
- Re-registered reports need to have new created_date_time