### PR TITLE
Fix broken oadrRegisterReport test

### DIFF
--- a/test/test_message_conversion.py
+++ b/test/test_message_conversion.py
@@ -308,6 +308,7 @@ def test_message(message_type, data):
     # print("", file=file)
     # print("", file=file)
     if message_type == 'oadrRegisterReport':
+        data.pop('report_request_id')
         for report in data['reports']:
             for rd in report['report_descriptions']:
                 if 'measurement' in rd:


### PR DESCRIPTION
The `oadrRegisterReport` test case was broken due to the inclusion of `report_request_id: None` in the data dict.