### PR TITLE
Fixed problem with removing events during clean up

### DIFF
--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -1012,7 +1012,7 @@ class OpenADRClient:
             if event['event_descriptor']['event_status'] == 'cancelled' or \
                     utils.determine_event_status(event['active_period']) == 'completed':
                 logger.info(f"Removing event {event} because it is no longer relevant.")
-                self.received_events.pop(self.received_events.index(event))
+                self.received_events.pop(i)
 
     async def _poll(self):
         logger.debug("Now polling for new messages")

--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -1007,7 +1007,8 @@ class OpenADRClient:
         """
         Periodic task that will clean up completed and cancelled events in our memory.
         """
-        for event in self.received_events:
+        for i in range(len(self.received_events)-1, -1, -1):
+            event = self.received_events[i]
             if event['event_descriptor']['event_status'] == 'cancelled' or \
                     utils.determine_event_status(event['active_period']) == 'completed':
                 logger.info(f"Removing event {event} because it is no longer relevant.")

--- a/test/test_message_conversion.py
+++ b/test/test_message_conversion.py
@@ -308,6 +308,7 @@ def test_message(message_type, data):
     # print("", file=file)
     # print("", file=file)
     if message_type == 'oadrRegisterReport':
+        data.pop('report_request_id')
         for report in data['reports']:
             for rd in report['report_descriptions']:
                 if 'measurement' in rd:


### PR DESCRIPTION
In the client's `_event_cleanup` popping items during iteration could cause missing events if two adjacent events in the list are to be removed. Iterating in reverse fixes this issue.