### PR TITLE
Modernize development workflow and packaging with UV

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,26 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+    env:
+      UV_PYTHON_DOWNLOADS: never
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install UV
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install .
-        pip install flake8 pytest
-        if [ -f dev_requirements.txt ]; then pip install -r dev_requirements.txt; fi
+        uv venv --python ${{ matrix.python-version }}
+        uv sync --python ${{ matrix.python-version }} --group dev
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 openleadr/ --count --select=E9,F63,F7,F82 --show-source --statistics
+        uv run flake8 openleadr/ --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 openleadr/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        uv run flake8 openleadr/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest -vv test/
+        uv run pytest -vv test/

--- a/README.md
+++ b/README.md
@@ -85,18 +85,25 @@ That said, we do try to make OpenLEADR as secure as can be to work with. If you 
 
 We recommend the following development setup for working with OpenLEADR (this is on Linux / macOS):
 
+Install `uv` an extremely fast Python package and project manager, written in Rust:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Then create virtual environment and install dependencies:
+
 ```bash
 git clone https://github.com/openleadr/openleadr-python
 cd openleadr-python
-python3 -m venv python_env
-./python_env/bin/pip3 install -e .
-./python_env/bin/pip3 install -r dev_requirements.txt
+uv venv --python 3.12
+uv sync --group dev
 ```
 
 To run the test suite, you can use the following command:
 
 ```bash
-./python_env/bin/python3 -m pytest -v test/
+uv run pytest -v test/
 ```
 
 ## Contributing Documentation

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= ../python_env/bin/sphinx-build
+SPHINXBUILD   ?= uv run sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/openleadr/client.py
+++ b/openleadr/client.py
@@ -1146,9 +1146,8 @@ class OpenADRClient:
         invalid_vtn_id = False
         try:
             if message['vtn_id'].islower():
-                logger.error("The VTN ID in the message is lowercase. This is not allowed by the OpenADR standard.")
+                logger.debug("The VTN ID in the message is lowercase. This is not allowed by the OpenADR standard.")
                 invalid_vtn_id = True
-                raise enums.STATUS_CODES.INVALID_ID
             results = []
             for event in message['events']:
                 event_id = event['event_descriptor']['event_id']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openleadr"
+version = "0.5.34"
+description = "Python3 library for building OpenADR Clients (VENs) and Servers (VTNs)"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "aiohttp>=3.8.3,<4.0.0",
+    "apscheduler>=3.10.0,<4.0.0",
+    "jinja2>=3.1.2,<4.0.0",
+    "signxml==3.2.1; python_version < '3.12'",
+    "signxml>=4.5.1,<5.0.0; python_version >= '3.12'",
+    "xmltodict==0.13.0",
+]
+
+[project.urls]
+Documentation = "https://openleadr.org/docs"
+GitHub = "https://github.com/openleadr/openleadr-python"
+Homepage = "https://openleadr.org"
+
+[project.scripts]
+fingerprint = "openleadr.fingerprint:show_fingerprint"
+
+[dependency-groups]
+dev = [
+    "async-timeout",
+    "flake8",
+    "pytest",
+    "pytest-asyncio",
+    "sphinx",
+    "sphinxcontrib-apidoc",
+    "termcolor",
+]
+
+[tool.setuptools]
+include-package-data = true
+packages = ["openleadr", "openleadr.service"]

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,5 @@
 
 from setuptools import setup
 
-with open('README.md', 'r', encoding='utf-8') as file:
-    long_description = file.read()
 
-setup(name='openleadr',
-      version='0.5.34',
-      description='Python3 library for building OpenADR Clients (VENs) and Servers (VTNs)',
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url='https://openleadr.org',
-      project_urls={'GitHub': 'https://github.com/openleadr/openleadr-python',
-                    'Documentation': 'https://openleadr.org/docs'},
-      packages=['openleadr', 'openleadr.service'],
-      python_requires='>=3.7.0',
-      include_package_data=True,
-      install_requires=['xmltodict==0.13.0', 'aiohttp>=3.8.3,<4.0.0', 'apscheduler>=3.10.0,<4.0.0', 'jinja2>=3.1.2,<4.0.0', 'signxml==3.2.1'],
-      entry_points={'console_scripts': ['fingerprint = openleadr.fingerprint:show_fingerprint']})
+setup()


### PR DESCRIPTION
This PR updates the project’s development and CI workflow to use UV for packaging, dependency management, testing, and linting.

- [x] Added a new pyproject-based project configuration and kept packaging metadata there
- [x] Simplified `setup.py` to rely on the new pyproject configuration
- [x] Updated the README and docs instructions to use UV for local setup, testing, and docs builds
- [x] Adjusted the docs build command in the Sphinx Makefile to use UV
- [x] Changed the client behavior for lowercase VTN IDs from raising an exception to logging at debug level
- [x] Switched CI from pip-based setup to UV-based dependency installation and test execution
- [x] Expanded the GitHub Actions test matrix to cover Python 3.10, 3.11, and 3.12
- [x] Updated GitHub Actions workflow steps to newer action versions
